### PR TITLE
CPU Hog Fix

### DIFF
--- a/include/os/windows/spl/sys/condvar.h
+++ b/include/os/windows/spl/sys/condvar.h
@@ -114,7 +114,7 @@ int cv_timedwait_hires(kcondvar_t *cvp, struct kmutex *mp,
 	cv_timedwait_hires((cvp), (mp), TICK_TO_NSEC((tim)), 0, 0)
 
 #define	cv_timedwait_idle_hires(cvp, mp, tim, res, flag)        \
-	cv_timedwait_hires(cvp, mp, tim, res, (flag)|PCATCH)
+	cv_timedwait_hires(cvp, mp, tim, res, flag)
 
 #define	cv_init spl_cv_init
 #define	cv_destroy spl_cv_destroy


### PR DESCRIPTION
In file include/os/windows/spl/sys/condvar.h, there is macro definition for 'cv_timedwait_idle_hires_'. Compared to ZFSin, the flag parameter is changed to include PCATCH (same value as CALLOUT_FLAG_ABSOLUTE).

#define cv_timedwait_idle_hires(cvp, mp, tim, res, flag)
cv_timedwait_hires(cvp, mp, tim, res, (flag)|PCATCH)

The threads zthr_procedure(),dbuf_evict_thread call into this macro/function. In cv_timedwait_hires() (in file spl-condvar.c), the
condition check for flag CALLOUT_FLAG_ABSOLUTE is becoming true. so the 'timeout' value is getting changed to incorrect value and the thread does not wait enough (callers pass 1 sec and not absolute value) on the lock event.