### PR TITLE
zpool import not working

### DIFF
--- a/module/os/windows/zfs/vdev_disk.c
+++ b/module/os/windows/zfs/vdev_disk.c
@@ -318,8 +318,6 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	RtlInitUnicodeString(&defaultFilterName, L"\\Driver\\partmgr");
 
 	DeviceObject = FileObject->DeviceObject; // bottom of stack
-	ObReferenceObject(DeviceObject);
-	dvd->vd_DeviceObject = DeviceObject;
 
 	/*
 	 * Determine the actual size of the device.
@@ -405,6 +403,9 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 
 	dvd->vd_FileObject = FileObject;
 	dvd->vd_ExclusiveObject = DeviceObject;
+
+	dvd->vd_DeviceObject = DeviceObject;
+	ObReferenceObject(dvd->vd_DeviceObject);
 
 	// Make disk readonly and offline, so that users can't
 	// partition/format it.


### PR DESCRIPTION
Zpool Import functionality is broken as reported in issue#14. It fails to read vdev label on Windows 2019 but succeeds in windows 10.

Currently, the read IRP's are sent to FileObject->DeviceObject. On windows 2019, The FileObject->DeviceObject->DriverObject->DriverName is different based on the disk device name. For device names like \??\PHYSICALDRIVE1, it is \Driver\disk. For scsi device names (eg \??\scsi#disk&ven_vbox&prod_harddisk#4&2617aeae&0&020000#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}, it is \Driver\storahci.

So assigning the dvd->vd_DeviceObject to the driver below \Driver\partmgr in the device stack as in ZFSin which would be \Driver\disk.