### PR TITLE
Fix for Data Miscompare/validation Error.

### DIFF
--- a/module/os/windows/zfs/zfs_windows_zvol_scsi.c
+++ b/module/os/windows/zfs/zfs_windows_zvol_scsi.c
@@ -966,6 +966,8 @@ wzvol_WkRtn(__in PVOID pWkParms)
 	zfs_uio_iovec_init(&uio, &iov, 1, 0, UIO_SYSSPACE, pSrb->DataTransferLength, 0);
 	//    ActionRead == pWkRtnParms->Action ? UIO_READ : UIO_WRITE);
 
+	zfs_uio_setoffset(&uio, sectorOffset);
+
 	/* Call ZFS to read/write data */
 	if (ActionRead == pWkRtnParms->Action) {
 		status = zvol_os_read_zv(zv, &uio, flags);

--- a/module/os/windows/zfs/zfs_windows_zvol_scsi.c
+++ b/module/os/windows/zfs/zfs_windows_zvol_scsi.c
@@ -963,10 +963,8 @@ wzvol_WkRtn(__in PVOID pWkParms)
 	iov.iov_len = pSrb->DataTransferLength;
 
 	zfs_uio_t uio;
-	zfs_uio_iovec_init(&uio, &iov, 1, 0, UIO_SYSSPACE, pSrb->DataTransferLength, 0);
+	zfs_uio_iovec_init(&uio, &iov, 1, sectorOffset, UIO_SYSSPACE, pSrb->DataTransferLength, 0);
 	//    ActionRead == pWkRtnParms->Action ? UIO_READ : UIO_WRITE);
-
-	zfs_uio_setoffset(&uio, sectorOffset);
 
 	/* Call ZFS to read/write data */
 	if (ActionRead == pWkRtnParms->Action) {


### PR DESCRIPTION
Fix for Data Miscompare/validation Error as reported in issue https://github.com/openzfsonwindows/openzfs/issues/27.

Fix:-
The uio sector offset was not set during read/write.