### PR TITLE
ssv-20352 Handled WMI method GetDiscoveredPortAttributes()

### DIFF
--- a/module/os/windows/zfs/zfs_windows_zvol_wmi.c
+++ b/module/os/windows/zfs/zfs_windows_zvol_wmi.c
@@ -779,6 +779,29 @@ ExecuteWmiMethod(
 
 			switch (MethodId) {
 
+				case GetDiscoveredPortAttributes: {
+					PGetDiscoveredPortAttributes_OUT pOut =
+					    (PGetDiscoveredPortAttributes_OUT)
+					    pBuffer;
+					sizeNeeded =
+					    GetDiscoveredPortAttributes_OUT_SIZE;
+
+					if (OutBufferSize >= sizeNeeded) {
+						memset(pOut, 0, sizeNeeded);
+
+						// since this is a virtual
+						// driver with no discovered
+						// ports,always return an error
+						pOut->HBAStatus =
+						    HBA_STATUS_ERROR_ILLEGAL_INDEX;
+					} else {
+						status =
+						    SRB_STATUS_DATA_OVERRUN;
+					}
+
+					break;
+				}
+
 				case RefreshInformation: {
 					break;
 				}


### PR DESCRIPTION
Issue:- The GetDiscoveredPortAttributes() WMI method was not implemented for the WMI class MSFC_HBAAdapterMethods. This was causing problem with SCVMM setup.

Fix:- Implemented the GetDiscoveredPortAttributes method for the WMI class. 

To Test:- Execute the below WMI query from Powershell and it should not return any error.

Get-WMIObject -Class MSFC_HBAAdapterMethods -Namespace root\wmi | ForEach-Object {$_.GetDiscoveredPortAttributes(0,0)}