### PR TITLE
Setting 'NumberOfPhysicalBreaks=0x21', this will make sure the max IO…

### DIFF
--- a/module/os/windows/zfs/zfs_windows_zvol.c
+++ b/module/os/windows/zfs/zfs_windows_zvol.c
@@ -229,6 +229,7 @@ wzvol_HwFindAdapter(
 	pConfigInfo->VirtualDevice = TRUE;
 	pConfigInfo->WmiDataProvider = TRUE;
 	pConfigInfo->MaximumTransferLength = SP_UNINITIALIZED_VALUE;
+	pConfigInfo->NumberOfPhysicalBreaks = 0x21; // 128K IO size
 	pConfigInfo->AlignmentMask = 0x3;
 	pConfigInfo->CachesData = FALSE;
 	pConfigInfo->ScatterGather = TRUE;


### PR DESCRIPTION
This is merging of the PR https://github.com/openzfsonwindows/ZFSin/pull/339 from zfsin.

By changing 'pConfigInfo->NumberOfPhysicalBreaks = 0x21' we are able to improve ZFSin performance by 50%(for >=128K workloads).
Default 'NumberOfPhysicalBreaks' is set to 0x11, that is 64K, so for every 128K read/write storport will send two request to ZFSin, now changing the value to 0x21 reduced the number of request by half and thus improving the performance.