### PR TITLE
case insensitive path compare for windows zpool devices

### DIFF
--- a/lib/libzutil/zutil_device_path.c
+++ b/lib/libzutil/zutil_device_path.c
@@ -131,7 +131,12 @@ zfs_strcmp_shortname(const char *name, const char *cmp_name, int wholedisk)
 		if (wholedisk)
 			path_len = zfs_append_partition(path_name, MAXPATHLEN);
 
+#ifdef _WIN32
+		if ((path_len == cmp_len) &&
+		    stricmp(path_name, cmp_name) == 0) {
+#else
 		if ((path_len == cmp_len) && strcmp(path_name, cmp_name) == 0) {
+#endif
 			error = 0;
 			break;
 		}


### PR DESCRIPTION
Not able to remove devices from zpool.

----------------------------------------------------------------------------------------
Z:\x64-Debug\bin>zpool create pool1 PHYSICALDRIVE1 PHYSICALDRIVE2
Expanded path to '\\?\PHYSICALDRIVE1'
Expanded path to '\\?\PHYSICALDRIVE2'
working on dev '#1048576#4284481536#\\?\PHYSICALDRIVE1'
setting path here '/dev/physicaldrive1'
setting physpath here '#1048576#4284481536#\\?\PHYSICALDRIVE1'
working on dev '#1048576#32201768960#\\?\PHYSICALDRIVE2'
setting path here '/dev/physicaldrive2'
setting physpath here '#1048576#32201768960#\\?\PHYSICALDRIVE2'

Z:\x64-Debug\bin>zpool add pool1 PHYSICALDRIVE3
Expanded path to '\\?\PHYSICALDRIVE3'
working on dev '#1048576#1667235840#\\?\PHYSICALDRIVE3'
setting path here '/dev/physicaldrive3'
setting physpath here '#1048576#1667235840#\\?\PHYSICALDRIVE3'

Z:\x64-Debug\bin>zpool status
  pool: pool1
 state: ONLINE
config:

        NAME              STATE     READ WRITE CKSUM
        pool1             ONLINE       0     0     0
          physicaldrive1  ONLINE       0     0     0
          physicaldrive2  ONLINE       0     0     0
          physicaldrive3  ONLINE       0     0     0

errors: No known data errors

**Z:\x64-Debug\bin>zpool remove pool1 PHYSICALDRIVE3
cannot remove PHYSICALDRIVE3: no such device in pool**

Z:\x64-Debug\bin>zpool remove pool1 physicaldrive3

Z:\x64-Debug\bin>zpool status
  pool: pool1
 state: ONLINE
remove: Removal of vdev 2 copied 9.50K in 0h0m, completed on Wed Nov 17 04:00:02 2021
        96 memory used for removed device mappings
config:

        NAME              STATE     READ WRITE CKSUM
        pool1             ONLINE       0     0     0
          physicaldrive1  ONLINE       0     0     0
          physicaldrive2  ONLINE       0     0     0

errors: No known data errors
