### PR TITLE
Setting the FILE_OBJECT minor value in the zfs device object state

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7444,7 +7444,12 @@ zfsdev_state_init(void *priv)
 
 	ASSERT(MUTEX_HELD(&zfsdev_state_lock));
 
+#if defined(_WIN32) && defined(_KERNEL)
+	minor = minor((dev_t)priv);
+#else
 	minor = zfsdev_minor_alloc();
+#endif
+
 	if (minor == 0)
 		return (SET_ERROR(ENXIO));
 


### PR DESCRIPTION
As mentioned in https://github.com/openzfsonwindows/openzfs/issues/64 , the File_Object minor value is not correctly set in the zfs device object state. So the minor value is not found in the ZFS device object state list during close handle and hence does not get released.