### PR TITLE
fixed FILE_OBJECT corruption issue for the ZFS device object

### DIFF
--- a/module/os/windows/zfs/zfs_ioctl_os.c
+++ b/module/os/windows/zfs/zfs_ioctl_os.c
@@ -688,9 +688,8 @@ zfsdev_get_dev(void)
 void
 zfsdev_private_set_state(void *priv, zfsdev_state_t *zs)
 {
-	zfsdev_state_t **actual_zs = (zfsdev_state_t **)priv;
-	if (actual_zs != NULL)
-		*actual_zs = zs;
+	UNREFERENCED_PARAMETER(priv);
+	UNREFERENCED_PARAMETER(zs);
 }
 
 /* Loop all zs looking for matching dev_t */


### PR DESCRIPTION
As described in https://github.com/openzfsonwindows/openzfs/issues/64, the function zfsdev_private_set_state()  corrupts the FILE_OBJECT passed in the 'priv' parameter. As commented in the function, this function is not supposed to do anything. So defined it as empty.