### PR TITLE
changed zfs_wrlog_data_max parameter to uint64_t

### DIFF
--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -59,7 +59,7 @@ struct dsl_deadlist;
 
 extern uint64_t zfs_dirty_data_max;
 extern uint64_t zfs_dirty_data_max_max;
-extern unsigned long zfs_wrlog_data_max;
+extern uint64_t zfs_wrlog_data_max;
 extern int zfs_dirty_data_sync_percent;
 extern int zfs_dirty_data_max_percent;
 extern int zfs_dirty_data_max_max_percent;

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -110,7 +110,7 @@ int zfs_dirty_data_max_max_percent = 25;
  * until log data is cleared out after txg sync.
  * It only counts TX_WRITE log with WR_COPIED or WR_NEED_COPY.
  */
-unsigned long zfs_wrlog_data_max = 0;
+uint64_t zfs_wrlog_data_max = 0;
 
 /*
  * If there's at least this much dirty data (as a percentage of


### PR DESCRIPTION
changed zfs_wrlog_data_max parameter to uint64_t to avoid overflow.
The default value of zfs_wrlog_data_max = zfs_dirty_data_max * 2;
=4GB * 2 which overflows long and this impacts I/O performance.