### PR TITLE
using lookasidelist for abd_chunk_cache

### DIFF
--- a/include/os/windows/spl/sys/lookasidelist.h
+++ b/include/os/windows/spl/sys/lookasidelist.h
@@ -1,0 +1,21 @@
+#ifndef _SPL_LOOKASIDELIST_H
+#define	_SPL_LOOKASIDELIST_H
+
+extern void* osif_malloc(uint64_t);
+extern void osif_free(void*, uint64_t);
+
+#define	ZFS_LookAsideList_DRV_TAG '!SFZ'
+
+typedef struct lookasidelist_cache {
+    ULONG cache_active_allocations;
+    size_t cache_chunksize; // cache object size
+    LOOKASIDE_LIST_EX lookasideField;
+} lookasidelist_cache_t;
+
+lookasidelist_cache_t *lookasidelist_cache_create(size_t size);
+void lookasidelist_cache_destroy(lookasidelist_cache_t *pLookasidelist_cache);
+void* lookasidelist_cache_alloc(lookasidelist_cache_t *pLookasidelist_cache);
+void lookasidelist_cache_free(lookasidelist_cache_t *pLookasidelist_cache,
+    void *buf);
+
+#endif

--- a/module/os/windows/spl/CMakeLists.txt
+++ b/module/os/windows/spl/CMakeLists.txt
@@ -29,6 +29,7 @@ wdk_add_library(splkern
   spl-vnode.c
   spl-windows.c
   spl-xdr.c
+  spl-lookasidelist.c
 )
 
 # set(CMAKE_TOOLCHAIN_FILE $ENV{CMAKE_TOOLCHAIN_FILE})

--- a/module/os/windows/spl/spl-lookasidelist.c
+++ b/module/os/windows/spl/spl-lookasidelist.c
@@ -1,0 +1,98 @@
+#include <sys/zfs_context.h>
+#include <sys/lookasidelist.h>
+
+void *
+allocate_func(
+    __in POOL_TYPE  PoolType,
+    __in SIZE_T  NumberOfBytes,
+    __in ULONG  Tag,
+    __inout PLOOKASIDE_LIST_EX  Lookaside)
+{
+	lookasidelist_cache_t *pLookasidelist_cache;
+	pLookasidelist_cache = CONTAINING_RECORD(Lookaside,
+	    lookasidelist_cache_t, lookasideField);
+	void *buf = osif_malloc(NumberOfBytes);
+	ASSERT(buf != NULL);
+
+	if (buf != NULL) {
+		atomic_inc_32(&pLookasidelist_cache->cache_active_allocations);
+		// can also be calculated from the Lookaside list as below
+		// Lookaside->L.TotalAllocates - Lookaside->L.TotalFrees
+	}
+
+	return (buf);
+}
+
+void free_func(
+    __in PVOID  Buffer,
+    __inout PLOOKASIDE_LIST_EX  Lookaside
+) {
+	lookasidelist_cache_t *pLookasidelist_cache;
+	pLookasidelist_cache = CONTAINING_RECORD(Lookaside,
+	    lookasidelist_cache_t, lookasideField);
+	osif_free(Buffer, pLookasidelist_cache->cache_chunksize);
+	atomic_dec_32(&pLookasidelist_cache->cache_active_allocations);
+}
+
+lookasidelist_cache_t *
+lookasidelist_cache_create(size_t size)
+{
+	lookasidelist_cache_t *pLookasidelist_cache;
+	pLookasidelist_cache = ExAllocatePoolWithTag(NonPagedPool,
+	    sizeof (lookasidelist_cache_t), ZFS_LookAsideList_DRV_TAG);
+
+	if (pLookasidelist_cache != NULL) {
+		NTSTATUS retval = ExInitializeLookasideListEx(
+		    &pLookasidelist_cache->lookasideField,
+		    allocate_func,
+		    free_func,
+		    NonPagedPoolNx,
+		    0,
+		    size,
+		    ZFS_LookAsideList_DRV_TAG,
+		    0);
+
+		ASSERT(retval == STATUS_SUCCESS);
+
+		if (retval == STATUS_SUCCESS) {
+			pLookasidelist_cache->cache_chunksize = size;
+			pLookasidelist_cache->cache_active_allocations = 0;
+		} else {
+			ExFreePoolWithTag(pLookasidelist_cache,
+			    ZFS_LookAsideList_DRV_TAG);
+			pLookasidelist_cache = NULL;
+		}
+	}
+
+	return (pLookasidelist_cache);
+}
+
+void
+lookasidelist_cache_destroy(lookasidelist_cache_t *pLookasidelist_cache)
+{
+	if (pLookasidelist_cache != NULL) {
+		ExFlushLookasideListEx(&pLookasidelist_cache->lookasideField);
+		ExDeleteLookasideListEx(&pLookasidelist_cache->lookasideField);
+		ExFreePoolWithTag(pLookasidelist_cache,
+		    ZFS_LookAsideList_DRV_TAG);
+	}
+}
+
+void *
+lookasidelist_cache_alloc(lookasidelist_cache_t *pLookasidelist_cache)
+{
+	void *buf = ExAllocateFromLookasideListEx(
+	    &pLookasidelist_cache->lookasideField);
+	ASSERT(buf != NULL);
+	return (buf);
+}
+
+void
+lookasidelist_cache_free(lookasidelist_cache_t *pLookasidelist_cache, void *buf)
+{
+	ASSERT(buf != NULL);
+	if (buf != NULL) {
+		ExFreeToLookasideListEx(&pLookasidelist_cache->lookasideField,
+		    buf);
+	}
+}

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -253,8 +253,7 @@ arc_reclaim_thread(void *unused)
 		 * it is worth reaping the abd_chunk_cache
 		 */
 		if (d_adj >= 64LL*1024LL*1024LL) {
-			extern kmem_cache_t *abd_chunk_cache;
-			kmem_cache_reap_now(abd_chunk_cache);
+			abd_cache_reap_now();
 		}
 
 		free_memory = post_adjust_free_memory;


### PR DESCRIPTION
As described in issue https://github.com/openzfsonwindows/openzfs/issues/79 , Windows ZFS performance of  128k sequential write on zvol of volblocksize=128k was much less compared to Linux. Xperf trace showed much contention in abd_alloc_chunks(). So we tested by replacing kmem_cache with lookasidelist for abd chunk cache
and performance gain was over 40%. Lookasidelist is the windows implementation of object cache similar to kmem_cache on Linux.

This is the minimal implementation and further code review/changes would be required before integrating into the code base.

Reference:
https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/using-lookaside-lists