### PR TITLE
IoStatus from IRP to be used to set zio->io_error

### DIFF
--- a/module/os/windows/zfs/vdev_disk.c
+++ b/module/os/windows/zfs/vdev_disk.c
@@ -575,7 +575,7 @@ vdev_disk_io_start_done(__in PVOID pDummy, __in PVOID pWkParms)
 	IoFreeWorkItem(zio->windows.work_item);
 	zio->windows.work_item = NULL;
 
-	NTSTATUS status = zio->windows.IoStatus.Status;
+	NTSTATUS status = zio->windows.irp->IoStatus.Status;
 	zio->io_error = (!NT_SUCCESS(status) ? EIO : 0);
 
 	UnlockAndFreeMdl(zio->windows.irp->MdlAddress);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->It fixes https://github.com/openzfsonwindows/openzfs/issues/85