### PR TITLE
Free the lookasidelist_cache and its kstat member pointer in correct order

### DIFF
--- a/module/os/windows/spl/spl-lookasidelist.c
+++ b/module/os/windows/spl/spl-lookasidelist.c
@@ -135,13 +135,14 @@ lookasidelist_cache_destroy(lookasidelist_cache_t *pLookasidelist_cache)
 	if (pLookasidelist_cache != NULL) {
 		ExFlushLookasideListEx(&pLookasidelist_cache->lookasideField);
 		ExDeleteLookasideListEx(&pLookasidelist_cache->lookasideField);
-		ExFreePoolWithTag(pLookasidelist_cache,
-		    ZFS_LookAsideList_DRV_TAG);
 
 		if (pLookasidelist_cache->cache_kstat != NULL) {
 			kstat_delete(pLookasidelist_cache->cache_kstat);
 			pLookasidelist_cache->cache_kstat = NULL;
 		}
+
+		ExFreePoolWithTag(pLookasidelist_cache,
+		    ZFS_LookAsideList_DRV_TAG);
 	}
 }
 


### PR DESCRIPTION
Bug check during driver uninstallation with driver verifier on.
Issue:- Dereferencing the 'pLookasidelist_cache' pointer after it is freed.

---------------------------------------------------------------------------------------------------------------------------------------
PAGE_FAULT_IN_NONPAGED_AREA (50)
Invalid system memory was referenced.  This cannot be protected by try-except.
Typically the address is just plain bad or it is pointing at freed memory.

FAULTING_SOURCE_LINE:  C:\mergezfsdestroy\openzfs\module\os\windows\spl\spl-lookasidelist.c

FAULTING_SOURCE_FILE:  C:\mergezfsdestroy\openzfs\module\os\windows\spl\spl-lookasidelist.c

FAULTING_SOURCE_LINE_NUMBER:  141

FAULTING_SOURCE_CODE:  
   137: 		ExDeleteLookasideListEx(&pLookasidelist_cache->lookasideField);
   138: 		ExFreePoolWithTag(pLookasidelist_cache,
   139: 		    ZFS_LookAsideList_DRV_TAG);
   140: 
>  141: 		if (pLookasidelist_cache->cache_kstat != NULL) {
   142: 			kstat_delete(pLookasidelist_cache->cache_kstat);
   143: 			pLookasidelist_cache->cache_kstat = NULL;
   144: 		}
   145: 	}
   146: }