### PR TITLE
 After zpool export , zvols still appear in the disk management

### DIFF
--- a/module/os/windows/zfs/zvol_os.c
+++ b/module/os/windows/zfs/zvol_os.c
@@ -671,6 +671,7 @@ zvol_os_detach_zv(zvol_state_t *zv)
 				rw_exit(&zv->zv_suspend_lock);
 			}
 		}
+		wzvol_announce_buschange();
 	}
 }
 


### PR DESCRIPTION
Fixed it by calling the StorPortNotification for Buschange