### PR TITLE
zdb read block: Debug assert fail for isprint() when char value > 127

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -7878,7 +7878,7 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 	int do_bswap = !!(flags & ZDB_FLAG_BSWAP);
 	unsigned i, j;
 	const char *hdr;
-	char *c;
+	unsigned char *c;
 
 
 	if (do_bswap)
@@ -7898,7 +7898,7 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 		    (u_longlong_t)(do_bswap ? BSWAP_64(d[i]) : d[i]),
 		    (u_longlong_t)(do_bswap ? BSWAP_64(d[i + 1]) : d[i + 1]));
 
-		c = (char *)&d[i];
+		c = (unsigned char *)&d[i];
 		for (j = 0; j < 2 * sizeof (uint64_t); j++)
 			(void) printf("%c", isprint(c[j]) ? c[j] : '.');
 		(void) printf("\n");


### PR DESCRIPTION
ZDB read block containing char value > 127. In debug build, Assert fails for isprint().
zdb.exe -R poolname vdev:offset:size

Reference:
https://www.codeproject.com/Questions/613965/isprint-is-leads-to-exe-crashing

![image](https://user-images.githubusercontent.com/84957265/176106977-0ddf7b83-dfd1-487b-814c-dcee5fa820af.png)
