### PR TITLE
Skip __zfs_dbgmsg in a DPC

### DIFF
--- a/module/os/windows/zfs/zfs_debug.c
+++ b/module/os/windows/zfs/zfs_debug.c
@@ -204,6 +204,13 @@ __dprintf(boolean_t dprint, const char *file, const char *func,
 	const char *newfile;
 
 	/*
+	 * Skip everything if we can't write to the debug log due to
+	 * being in a DPC.
+	 */
+	if (KeGetCurrentIrql() >= DISPATCH_LEVEL)
+		return;
+
+	/*
 	 * Get rid of annoying prefix to filename.
 	 */
 	newfile = strrchr(file, '/');

--- a/module/os/windows/zfs/zfs_debug.c
+++ b/module/os/windows/zfs/zfs_debug.c
@@ -204,6 +204,13 @@ __dprintf(boolean_t dprint, const char *file, const char *func,
 	const char *newfile;
 
 	/*
+	 * Skip everything if we can't write to the debug log due to
+	 * being in a DPC.
+	 */
+	if (KeGetCurrentIrql() >= DISPATCH_LEVEL)
+		return;
+
+	/*
 	 * Get rid of annoying prefix to filename.
 	 */
 	newfile = strrchr(file, '/');
@@ -252,12 +259,7 @@ __dprintf(boolean_t dprint, const char *file, const char *func,
 
 	DTRACE_PROBE1(zfs__dbgmsg, char *, zdm->zdm_msg);
 
-	/*
-	 * Skip __zfs_dbgmsg if we can't write to the debug log due to
-	 * being in a DPC.
-	 */
-	if (KeGetCurrentIrql() < DISPATCH_LEVEL)
-		__zfs_dbgmsg(buf);
+	__zfs_dbgmsg(buf);
 
 	/* Also emit string to log/console */
 	printBuffer("%s\n", buf);


### PR DESCRIPTION
Add a check to dprintf that will avoid trying to write to the debug log if we are in a IRQL of DISPATCH_LEVEL or higher.
Otherwise we will get a BSOD when __zfs_dbgmsg tries to grab a mutex.
https://github.com/openzfsonwindows/openzfs/issues/103

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
