### PR TITLE
ioctldeviceobject cleanup moved to IRP_MJ_CLOSE, TO avoid DV violation

### DIFF
--- a/module/os/windows/zfs/zfs_ioctl_os.c
+++ b/module/os/windows/zfs/zfs_ioctl_os.c
@@ -903,9 +903,6 @@ zfs_ioc_unregister_fs(void)
 		IoDeleteSymbolicLink(&ntWin32NameString);
 		IoDeleteDevice(fsDiskDeviceObject);
 		fsDiskDeviceObject = NULL;
-		ObDereferenceObject(ioctlDeviceObject);
-		IoDeleteDevice(ioctlDeviceObject);
-		ioctlDeviceObject = NULL;
 	}
 #if 0
 	// Do not unload these, so that the zfsinstaller uninstall can

--- a/module/os/windows/zfs/zfs_vnops_windows.c
+++ b/module/os/windows/zfs/zfs_vnops_windows.c
@@ -4825,6 +4825,18 @@ _Function_class_(DRIVER_DISPATCH)
 		break;
 	case IRP_MJ_CLOSE:
 		Status = zfsdev_release((dev_t)IrpSp->FileObject, Irp);
+
+		// uninstall
+		extern kmutex_t zfsdev_state_lock;
+		if (fsDiskDeviceObject == NULL) {
+		    mutex_enter(&zfsdev_state_lock);
+		    if (ioctlDeviceObject != NULL) {
+			ObDereferenceObject(ioctlDeviceObject);
+			IoDeleteDevice(ioctlDeviceObject);
+			ioctlDeviceObject = NULL;
+		    }
+		    mutex_exit(&zfsdev_state_lock);
+		}
 		break;
 	case IRP_MJ_DEVICE_CONTROL:
 		{


### PR DESCRIPTION
https://github.com/openzfsonwindows/openzfs/issues/102