### PR TITLE
Windows test runner fixes

### DIFF
--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -10,6 +10,14 @@ name: windows-build-test
 on:
   push:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run-failing:
+        type: boolean
+        default: true
+        description: Run tests that fail
+
+
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -72,7 +80,7 @@ jobs:
       run: git describe --always --long --dirty
 
     - name: Download Inno Setup istaller
-      uses: suisei-cn/actions-download-file@v1.0.1
+      uses: suisei-cn/actions-download-file@v1.3.0
       id: innoinstaller
       with:
         url: 'https://jrsoftware.org/download.php/is.exe'
@@ -227,7 +235,7 @@ jobs:
       run: wmic diskdrive list
 
 #    - name: Download
-#      uses: suisei-cn/actions-download-file@v1.0.1
+#      uses: suisei-cn/actions-download-file@v1.3.0
 #      #id: innoinstaller
 #      with:
 #        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/testdrives.zip'
@@ -239,7 +247,7 @@ jobs:
 #        Expand-Archive -LiteralPath ${{github.workspace}}/testdrives.zip -DestinationPath D:\
 #
 #    - name: Download
-#      uses: suisei-cn/actions-download-file@v1.0.1
+#      uses: suisei-cn/actions-download-file@v1.3.0
 #      #id: innoinstaller
 #      with:
 #        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/scriptname.txt'
@@ -459,6 +467,7 @@ jobs:
     needs: [build_windows] #, build_wsl]
     timeout-minutes: 30
     runs-on: windows-latest
+    if:  ${{ inputs.run-failing }}
     steps:
 
     - uses: actions/checkout@v3
@@ -479,7 +488,7 @@ jobs:
       run: wmic diskdrive list
 
 #    - name: Download
-#      uses: suisei-cn/actions-download-file@v1.0.1
+#      uses: suisei-cn/actions-download-file@v1.3.0
 #      #id: innoinstaller
 #      with:
 #        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/testdrives.zip'
@@ -491,7 +500,7 @@ jobs:
 #        Expand-Archive -LiteralPath ${{github.workspace}}/testdrives.zip -DestinationPath D:\
 #
 #    - name: Download
-#      uses: suisei-cn/actions-download-file@v1.0.1
+#      uses: suisei-cn/actions-download-file@v1.3.0
 #      #id: innoinstaller
 #      with:
 #        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/scriptname.txt'
@@ -518,7 +527,7 @@ jobs:
         echo $p
         $f = (Get-Item $p ).Name
         echo $f
-        echo "::set-output name=filename::$($f)"
+        echo "filename=$f" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     # https://github.com/MicrosoftDocs/windows-powershell-docs/issues/266
     - name: Import root certificate
@@ -584,14 +593,15 @@ jobs:
 
     - name: get pool mount
       id: drive  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:\\)"  | % {"::set-output name=drive::$($_.matches.groups[1].value)"}'
+      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:\\)"  | % {"drive=$($_.matches.groups[1].value)"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
+
 
     - name: echo
       run: echo ${{ steps.drive.outputs.drive }}
 
 
     - name: Download winbtrfs
-      uses: suisei-cn/actions-download-file@v1.0.1
+      uses: suisei-cn/actions-download-file@v1.3.0
       id: winbtrs  # Remember to give an ID if you need the output filename
       with:
         url: "https://github.com/andrewc12/btrfs/releases/download/v1.8/x64-Debug.zip"
@@ -625,12 +635,12 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" create ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs supersede tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" supersede ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs overwrite tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" overwrite ${{ steps.drive.outputs.drive }}'
 
@@ -640,12 +650,12 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" open_id ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs io tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" io ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs mmap tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" mmap ${{ steps.drive.outputs.drive }}'
 
@@ -655,7 +665,7 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" rename ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs rename_ex tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" rename_ex ${{ steps.drive.outputs.drive }}'
 
@@ -665,7 +675,7 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" delete ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs delete_ex tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" delete_ex ${{ steps.drive.outputs.drive }}'
 
@@ -675,12 +685,12 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" links ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs links_ex tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" links_ex ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs oplock_i tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" oplock_i ${{ steps.drive.outputs.drive }}'
 
@@ -690,7 +700,7 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" oplock_ii ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs oplock_batch tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" oplock_batch ${{ steps.drive.outputs.drive }}'
 
@@ -700,7 +710,7 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" oplock_filter ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs oplock_r tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" oplock_r ${{ steps.drive.outputs.drive }}'
 
@@ -710,12 +720,12 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" oplock_rw ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs oplock_rh tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" oplock_rh ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs oplock_rwh tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" oplock_rwh ${{ steps.drive.outputs.drive }}'
 
@@ -725,7 +735,7 @@ jobs:
       run: '& "${{github.workspace}}\winbtrfs\test.exe" cs ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs reparse tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" reparse ${{ steps.drive.outputs.drive }}'
 
@@ -734,22 +744,17 @@ jobs:
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" streams ${{ steps.drive.outputs.drive }}'
 
-    - name: run winbtrfs ea tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
-      run: |
-        echo these crash
-        exit 1
     #- name: run winbtrfs ea tests
     #  if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
     #  run: '& "${{github.workspace}}\winbtrfs\test.exe" ea ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs fileinfo tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" fileinfo ${{ steps.drive.outputs.drive }}'
 
     - name: run winbtrfs ea tests
-      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' }}
+      if: ${{ ( success() || failure() ) && steps.dummy.conclusion == 'success' && inputs.run-failing }}
       timeout-minutes: 1
       run: '& "${{github.workspace}}\winbtrfs\test.exe" ea ${{ steps.drive.outputs.drive }}'
 
@@ -810,7 +815,7 @@ jobs:
 #      run: wmic diskdrive list
 #
 ##    - name: Download
-##      uses: suisei-cn/actions-download-file@v1.0.1
+##      uses: suisei-cn/actions-download-file@v1.3.0
 ##      #id: innoinstaller
 ##      with:
 ##        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/testdrives.zip'
@@ -822,7 +827,7 @@ jobs:
 ##        Expand-Archive -LiteralPath ${{github.workspace}}/testdrives.zip -DestinationPath D:\
 ##
 ##    - name: Download
-##      uses: suisei-cn/actions-download-file@v1.0.1
+##      uses: suisei-cn/actions-download-file@v1.3.0
 ##      #id: innoinstaller
 ##      with:
 ##        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/scriptname.txt'
@@ -1150,7 +1155,7 @@ jobs:
 ##      run: 'bcdedit'
 ##
 ##    - name: Download winbtrfs
-##      uses: suisei-cn/actions-download-file@v1.0.1
+##      uses: suisei-cn/actions-download-file@v1.3.0
 ##      id: winbtrs  # Remember to give an ID if you need the output filename
 ##      with:
 ##        url: "https://github.com/andrewc12/btrfs/releases/download/v1.8/x64-Debug.zip"
@@ -1360,6 +1365,7 @@ jobs:
     needs: [build_windows] #, build_wsl]
     timeout-minutes: 30
     runs-on: windows-latest
+    if:  ${{ inputs.run-failing }}
     steps:
 
     - uses: actions/checkout@v3
@@ -1380,7 +1386,7 @@ jobs:
       run: wmic diskdrive list
 
 #    - name: Download
-#      uses: suisei-cn/actions-download-file@v1.0.1
+#      uses: suisei-cn/actions-download-file@v1.3.0
 #      #id: innoinstaller
 #      with:
 #        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/testdrives.zip'
@@ -1392,7 +1398,7 @@ jobs:
 #        Expand-Archive -LiteralPath ${{github.workspace}}/testdrives.zip -DestinationPath D:\
 #
 #    - name: Download
-#      uses: suisei-cn/actions-download-file@v1.0.1
+#      uses: suisei-cn/actions-download-file@v1.3.0
 #      #id: innoinstaller
 #      with:
 #        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/scriptname.txt'
@@ -1419,7 +1425,7 @@ jobs:
         echo $p
         $f = (Get-Item $p ).Name
         echo $f
-        echo "::set-output name=filename::$($f)"
+        echo "filename=$f" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     # https://github.com/MicrosoftDocs/windows-powershell-docs/issues/266
     - name: Import root certificate
@@ -1485,18 +1491,18 @@ jobs:
 
     - name: get pool mount
       id: drive  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:\\)"  | % {"::set-output name=drive::$($_.matches.groups[1].value)"}'
+      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:\\)"  | % {"drive=$($_.matches.groups[1].value)"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
 
     - name: get pool mount
       id: drivenoslash  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:)\\"  | % {"::set-output name=drive::$($_.matches.groups[1].value)"}'
+      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:)\\"  | % {"drive=$($_.matches.groups[1].value)"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
 
     - name: echo
       run: echo ${{ steps.drive.outputs.drive }}
 
 
     - name: Download winbtrfs
-      uses: suisei-cn/actions-download-file@v1.0.1
+      uses: suisei-cn/actions-download-file@v1.3.0
       id: winbtrs  # Remember to give an ID if you need the output filename
       with:
         url: "https://github.com/andrewc12/btrfs/releases/download/v1.8/x64-Debug.zip"
@@ -1531,7 +1537,7 @@ jobs:
 #          Copy-Item "${{github.workspace}}\out\build\x64-Debug\cmd\os\windows\winfstest\winfstest.exe" -Destination "${{ steps.drive.outputs.drive }}\winfstest"
 
     - name: Download
-      uses: suisei-cn/actions-download-file@v1.0.1
+      uses: suisei-cn/actions-download-file@v1.3.0
       #id: innoinstaller
       with:
         url: 'https://github.com/andrewc12/zfsfiledump/raw/main/winfstest.zip'
@@ -1557,3 +1563,299 @@ jobs:
           python ${{ steps.drive.outputs.drive }}\winfstest\simpletap.py --run
       shell: cmd
 
+
+
+
+
+
+
+  test4_adstest:
+    needs: [build_windows] #, build_wsl]
+    timeout-minutes: 30
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: windows-latest
+    if:  ${{ inputs.run-failing }}
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: dev_build_inno
+
+#    - uses: actions/download-artifact@v3
+#      with:
+#        name: build result
+
+#    - name: get files
+#      run: Get-ChildItem -Recurse
+
+    - name: get diskdrive
+      run: wmic diskdrive list
+
+
+    #- uses: suisei-cn/actions-download-file@v1.3.0
+    #  #id: innoinstaller
+    #  with:
+    #    url: 'https://github.com/andrewc12/zfsfiledump/raw/main/OpenZFSOnWindowsaa'
+    #    target: ${{github.workspace}}/
+
+
+
+    #- uses: suisei-cn/actions-download-file@v1.3.0
+    #  #id: innoinstaller
+    #  with:
+    #    url: 'https://github.com/andrewc12/zfsfiledump/raw/main/OpenZFSOnWindowsab'
+    #    target: ${{github.workspace}}/
+
+
+
+    #- uses: suisei-cn/actions-download-file@v1.3.0
+    #  #id: innoinstaller
+    #  with:
+    #    url: 'https://github.com/andrewc12/zfsfiledump/raw/main/OpenZFSOnWindowsac'
+    #    target: ${{github.workspace}}/
+
+
+
+    #- uses: suisei-cn/actions-download-file@v1.3.0
+    #  #id: innoinstaller
+    #  with:
+    #    url: 'https://github.com/andrewc12/zfsfiledump/raw/main/OpenZFSOnWindowsad'
+    #    target: ${{github.workspace}}/
+
+
+
+
+
+
+
+
+#    - name: Download
+#      uses: suisei-cn/actions-download-file@v1.3.0
+#      #id: innoinstaller
+#      with:
+#        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/testdrives.zip'
+#        target: ${{github.workspace}}/
+#
+#
+#    - name: make disk
+#      run: |
+#        Expand-Archive -LiteralPath ${{github.workspace}}/testdrives.zip -DestinationPath D:\
+#
+#    - name: Download
+#      uses: suisei-cn/actions-download-file@v1.3.0
+#      #id: innoinstaller
+#      with:
+#        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/scriptname.txt'
+#        target: ${{github.workspace}}/
+#
+#    - name: make disk
+#      run: |
+#        diskpart /s scriptname.txt
+#
+#
+#
+#    - name: get diskdrive
+#      run: wmic diskdrive list
+#
+#
+#    - name: get files
+#      run: Get-ChildItem -Recurse
+
+    #- run: copy /b OpenZFSOnWindowsaa+OpenZFSOnWindowsab+OpenZFSOnWindowsac+OpenZFSOnWindowsad OpenZFSOnWindows-a.exe
+    #  shell: cmd
+
+
+
+    - name: get zfsexename
+      id: zfsinstaller
+      run: |
+        $p = Get-ChildItem | Where-Object {$_.Name -like 'OpenZFSOnWindows-*.exe'} | Select-Object -first 1
+        echo $p
+        $f = (Get-Item $p ).Name
+        echo $f
+        echo "filename=$f" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+
+
+
+    - uses: suisei-cn/actions-download-file@v1.3.0
+      #id: innoinstaller
+      with:
+        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/ads_split.vhd.zst.001'
+        target: ${{github.workspace}}/
+
+
+
+    - uses: suisei-cn/actions-download-file@v1.3.0
+      #id: innoinstaller
+      with:
+        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/ads_split.vhd.zst.002'
+        target: ${{github.workspace}}/
+
+
+
+    - uses: suisei-cn/actions-download-file@v1.3.0
+      #id: innoinstaller
+      with:
+        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/ads_split.vhd.zst.003'
+        target: ${{github.workspace}}/
+
+
+
+    - uses: suisei-cn/actions-download-file@v1.3.0
+      #id: innoinstaller
+      with:
+        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/ads_split.vhd.zst.004'
+        target: ${{github.workspace}}/
+
+
+
+    - uses: suisei-cn/actions-download-file@v1.3.0
+      #id: innoinstaller
+      with:
+        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/ads_split.vhd.zst.005'
+        target: ${{github.workspace}}/
+
+
+
+
+    - uses: suisei-cn/actions-download-file@v1.3.0
+      #id: innoinstaller
+      with:
+        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/ads_split.vhd.zst.006'
+        target: ${{github.workspace}}/
+
+
+
+    - uses: suisei-cn/actions-download-file@v1.3.0
+      #id: innoinstaller
+      with:
+        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/ads_split.vhd.zst.007'
+        target: ${{github.workspace}}/
+
+
+
+
+    - uses: suisei-cn/actions-download-file@v1.3.0
+      #id: innoinstaller
+      with:
+        url: 'https://github.com/andrewc12/zfsfiledump/raw/main/ads_split.vhd.zst.008'
+        target: ${{github.workspace}}/
+
+
+
+
+    - run: copy /b ads_split.vhd.zst.001+ads_split.vhd.zst.002+ads_split.vhd.zst.003+ads_split.vhd.zst.004+ads_split.vhd.zst.005+ads_split.vhd.zst.006+ads_split.vhd.zst.007+ads_split.vhd.zst.008 ads_split.vhd.zst
+      shell: cmd
+
+
+
+
+    # https://github.com/MicrosoftDocs/windows-powershell-docs/issues/266
+    - name: Import root certificate
+      run: |
+        $plaintextpwd = 'password1234'
+        $pwd = ConvertTo-SecureString -String $plaintextpwd -Force -AsPlainText
+        Import-PfxCertificate -FilePath ${{github.workspace}}/contrib/windows/TestCert/test_sign_cert_pass.pfx -CertStoreLocation Cert:\LocalMachine\Root -Password $pwd
+        Import-PfxCertificate -FilePath ${{github.workspace}}/contrib/windows/TestCert/test_sign_cert_pass.pfx -CertStoreLocation Cert:\LocalMachine\TrustedPublisher -Password $pwd
+
+    - name: debug - echo filename
+      run: echo ${{ steps.zfsinstaller.outputs.filename }}
+
+#    - name: debug - list
+#      run: ls ${{github.workspace}}\
+
+    - name: debug - list
+      run: ls ${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}
+
+    #- name: install zfs
+    #  run: ${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }} /NORESTART /ALLUSERS /VERYSILENT /LOG="${{github.workspace}}\InnoSetup-Install.log"
+
+    - name: install zfs
+      run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
+
+    #- name: Wait for install to finish
+    #  run: Start-Sleep -Seconds 30
+    #  uses: iFaxity/wait-on-action@v1
+    #  with:
+    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
+
+#    - name: debug - print log
+#      run: cat "${{github.workspace}}\InnoSetup-Install.log"
+#
+#    - name: debug - list
+#      run: ls "C:\Program Files"
+#
+#    - name: debug - list
+#      run: ls "C:\Program Files\OpenZFS On Windows"
+
+    - name: debug - get status
+      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+
+
+
+
+
+
+
+    - name: Create backing files
+      run: |
+          $f = new-object System.IO.FileStream ${{github.workspace}}\test01.dat, Create, ReadWrite
+          $f.SetLength(1GB)
+          $f.Close()
+
+    - name: create pool
+      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
+
+    - name: get pool status
+      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+
+    - name: get pool mount
+      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe" mount'
+
+    - name: get pool mount
+      id: drive  # Remember to give an ID if you need the output filename
+      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:\\)"  | % {"drive=$($_.matches.groups[1].value)"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
+
+    - name: echo
+      run: echo ${{ steps.drive.outputs.drive }}
+
+    - name: extract
+      run: zstd -d ${{github.workspace}}\ads_split.vhd.zst
+
+
+    - name: get diskdrive
+      run: wmic diskdrive list
+
+    - name: get diskdrive
+      run: (Get-PSDrive).Name -match '^[a-z]$'
+
+
+    - name: Create backing files
+      id: drive2  # Remember to give an ID if you need the output filename
+      run: |
+          $mountResult = Mount-DiskImage ${{github.workspace}}\ads_split.vhd -PassThru
+          $mountResult | Get-Volume
+          echo "drive=F:"| Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+          #$mountResult | Get-Volume | % {"drive=$($_.matches.groups[1].value)"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+
+    - name: get diskdrive
+      run: wmic diskdrive list
+
+
+    - name: get diskdrive
+      run: (Get-PSDrive).Name -match '^[a-z]$'
+
+    - name: echo
+      run: echo ${{ steps.drive2.outputs.drive }}
+
+
+    - name: run tests
+      run: robocopy ${{ steps.drive2.outputs.drive }}\curtin ${{ steps.drive.outputs.drive }}curtin /E /b /R:0 /W:0


### PR DESCRIPTION
This fixes up the windows test runner a bit to reduce the deprecation warnings we were getting.

It also changes the tests so that only the tests that currently pass are run, so this checks for regressions mostly.
You an still run all of the tests manually if you need to.

Finally it also runs a test to recreate the ads issue I have been having.
(This may need to be vised to something smaller that triggers the same issue)

