### PR TITLE
Ignore Wint-conversion errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ add_compile_options(
 	#-fms-extensions
 	-Wno-unused-function
 	-Wno-unused-label
+	#Visual Studio 2022 update 2022114 started breaking builds with errors
+	-Wno-int-conversion
 )
 endfunction()
 


### PR DESCRIPTION
I fixed some of the issues, but we were ignoring them before so we could just ignore them again.
Unless someone wants to go through and fix them.