### PR TITLE
Do not bug check when any WMI method is not implemented.

### DIFF
--- a/module/os/windows/zfs/zfs_windows_zvol_wmi.c
+++ b/module/os/windows/zfs/zfs_windows_zvol_wmi.c
@@ -762,13 +762,6 @@ ExecuteWmiMethod(
 		}
 
 				default:
-
-					__try {
-						DbgBreakPoint();
-					}
-					__except(EXCEPTION_EXECUTE_HANDLER) {
-					}
-
 					status = SRB_STATUS_INVALID_REQUEST;
 					break;
 			}
@@ -1036,12 +1029,6 @@ ExecuteWmiMethod(
 	}
 
 	default:
-		__try {
-			DbgBreakPoint();
-		}
-		__except(EXCEPTION_EXECUTE_HANDLER) {
-		}
-
 		status = SRB_STATUS_INVALID_REQUEST;
 		break;
 		}


### PR DESCRIPTION
As reported in https://github.com/openzfsonwindows/openzfs/issues/243, ExecuteWmiMethod() bug checks when WMI method is not implemented.