### PR TITLE
printBuffer: Fix stack overflow

### DIFF
--- a/module/os/windows/debug.c
+++ b/module/os/windows/debug.c
@@ -125,12 +125,18 @@ printBuffer(const char *fmt, ...)
 	va_list args;
 	va_start(args, fmt);
 	char buf[max_line_length];
-	_snprintf(buf, 18, "%p: ", PsGetCurrentThread());
+	int buf_used;
 
-	int tmp = _vsnprintf_s(&buf[17], sizeof (buf), max_line_length,
-	    fmt, args);
-	if (tmp >= max_line_length) {
-		_snprintf(&buf[17], 17, "buffer too small");
+	buf_used = _snprintf(buf, sizeof (buf), "%p: ", PsGetCurrentThread());
+	if (buf_used < 0) {
+		return;
+	}
+
+	int tmp = _vsnprintf_s(buf + buf_used, sizeof (buf) - buf_used,
+	    _TRUNCATE, fmt, args);
+
+	if (tmp < 0) {
+		_snprintf(buf + max_line_length - 7, 7, "TRUNC\n");
 	}
 
 	KeAcquireSpinLock(&cbuf_spin, &level);


### PR DESCRIPTION
The `printBuffer` function was not correctly limiting writes to buffer, we passed the full buffer size to `_vsnprintf_s` despite not starting at the first element. This allows for a buffer overflow of 17 bytes after the buffer.

The code is changed to account for this and to truncate the buffer and mark the end with a "TRUNC\n" if the buffer is not large enough.

With the current buffer size, the largest printable string is 1005 bytes (1024 - 18 byte header - 1 byte zero termination). Anything larger will result in the string being truncated.