### PR TITLE
tests: Clean up the existing tests.py

### DIFF
--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -2141,7 +2141,7 @@ jobs:
 
 
     - name: test
-      run: 'python.exe -u "${{github.workspace}}\contrib\windows\tests\tests.py" -path ${{github.workspace}}\'
+      run: 'python.exe -u "${{github.workspace}}\contrib\windows\tests\tests.py" --path ${{github.workspace}}\'
 
 
 


### PR DESCRIPTION
This cleans up the code of `tests.py` and makes it use the new functions from `utils.py`. This also makes the test sleep much less, ~~which is only still required before destroying the pool due to https://github.com/openzfsonwindows/openzfs/issues/282~~
