### PR TITLE
parsedump: Simplify by using poi instead of regex

### DIFF
--- a/contrib/windows/parsedump/parsedump.py
+++ b/contrib/windows/parsedump/parsedump.py
@@ -26,16 +26,7 @@ analyze = run("!analyze -v ; q")
 
 stack = run("k ; q")
 
-cbuf = run("dt OpenZFS!cbuf ; q")
-# print(cbuf)
-b = re.search(r"'dt OpenZFS!cbuf ; q'"
-              "[\\s\\S]+?(0x[0-9A-Za-z]{8}`[0-9A-Za-z]{8})",
-              cbuf)
-cbufaddr = b.group()[-19:]
-
-cbuf2 = run(
-    ".writemem C:\\cbuf.txt " + cbufaddr + " L100000 ; q",
-)
+cbuf = run(".writemem C:\\cbuf.txt poi(OpenZFS!cbuf) L100000 ; q")
 
 with open("C:\\stack.txt", "w") as file:
     file.write(analyze)


### PR DESCRIPTION
Instead of using `dt` on `OpenZFS!cbuf` and checking the output we can just use `poi(OpenZFS!cbuf)` in the `.writemem` command.