### PR TITLE
tests: Export specific pool in the snapshot tests

### DIFF
--- a/contrib/windows/tests/tests.py
+++ b/contrib/windows/tests/tests.py
@@ -100,7 +100,7 @@ def main():
             allocate_file(pool.mount_path / "test01.file", 1 * Size.KIB)
             run_cmd(ctx.ZFS, ["snapshot", "testsn01@friday"])
             allocate_file(pool.mount_path / "test02.file", 1 * Size.KIB)
-            run_cmd(ctx.ZPOOL, ["export", "-a"])
+            run_cmd(ctx.ZPOOL, ["export", "testsn01"])
             pool.destroy = False  # already exported
 
         #######################################################################
@@ -112,7 +112,7 @@ def main():
             run_cmd(ctx.ZFS, ["snapshot", "testsn02@friday"])
             allocate_file(pool.mount_path / "test02.file", 1 * Size.KIB)
             run_cmd(ctx.ZFS, ["mount", "testsn02@friday"])
-            run_cmd(ctx.ZPOOL, ["export", "-a"])
+            run_cmd(ctx.ZPOOL, ["export", "testsn02"])
             pool.destroy = False  # already exported
 
         #######################################################################


### PR DESCRIPTION
The test currently exports all pools which makes it impossible to run other tests in parallel on a different drive letter. Instead we should only export the pool created by the test.