### PR TITLE
InnoSetup: write install location to the registry

### DIFF
--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -190,9 +190,31 @@ jobs:
     - name: debug - print log
       run: cat "${{github.workspace}}\InnoSetup-Install.log"
 
+    - name: Check InstallLocation Registry Value
+      shell: powershell
+      run: |
+        $registryPath = "HKLM:\Software\OpenZFS\OpenZFS On Windows"
+        $valueName = "InstallLocation"
+        $expectedValue = "C:\Program Files\OpenZFS On Windows"
 
+        if (-Not (Test-Path -Path $registryPath)) {
+          Write-Host "Registry path $registryPath does not exist."
+          exit 1
+        }
 
+        $registryValues = Get-ItemProperty -Path $registryPath
+        if (-Not ($registryValues.PSObject.Properties.Name -contains $valueName)) {
+          Write-Host "Registry path $registryPath does not contain value $valueName."
+          exit 1
+        }
 
+        $value = $registryValues.$valueName
+        if (-Not ($value -eq $expectedValue)) {
+          Write-Host "Registry value $valueName=$value not as expected, expected $expectedValue."
+          exit 1
+        }
+
+        Write-Host "Found installation location $value"
 
 
 

--- a/contrib/windows/Inno.Setup/ZFSInstall-debug.iss
+++ b/contrib/windows/Inno.Setup/ZFSInstall-debug.iss
@@ -58,6 +58,8 @@ WizardImageFile="{#SourcePath}\openzfs-large.bmp"
 ; SignTool=signtoola
 ; SignTool=signtoolb
 SignTool=signtoolc
+ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x64
 
 
 [Languages]
@@ -119,3 +121,6 @@ Filename: "{app}\ZFSInstaller.exe"; Parameters: "install .\OpenZFS.inf"; StatusM
 [UninstallRun]
 Filename: "{app}\ZFSInstaller.exe"; Parameters: "uninstall .\OpenZFS.inf"; RunOnceId: "driver"; Flags: runascurrentuser;
 
+[Registry]
+Root: HKLM; Subkey: "Software\{#MyAppPublisher}\{#MyAppName}"; Flags: uninsdeletekeyifempty
+Root: HKLM; Subkey: "Software\{#MyAppPublisher}\{#MyAppName}"; ValueType: string; ValueName: "InstallLocation"; ValueData: "{app}"


### PR DESCRIPTION
To get the installation location in scripts we write it to the registry in the key `HKLM\Software\OpenZFS\OpenZFS On Windows\InstallLocation`.

This also sets `ArchitecturesInstallIn64BitMode=x64` and `ArchitecturesAllowed=x64` because InnoSetup is a 32-bit process and needs to disable WOW64 redirection.