### PR TITLE
tests: read install location, don't install InnoSetup and add IS_STEP_DEBUG

### DIFF
--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -181,17 +181,10 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\contrib\windows\${{ steps.innoout.outputs.installername }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
     - name: debug - print log
       run: cat "${{github.workspace}}\InnoSetup-Install.log"
 
     - name: Check InstallLocation Registry Value
-      shell: powershell
       run: |
         $registryPath = "HKLM:\Software\OpenZFS\OpenZFS On Windows"
         $valueName = "InstallLocation"
@@ -323,23 +316,24 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.zfsinstallerfilename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
 #    - name: debug - print log
 #      run: cat "${{github.workspace}}\InnoSetup-Install.log"
-#
+
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
 #    - name: debug - list
 #      run: ls "C:\Program Files"
 #
 #    - name: debug - list
-#      run: ls "C:\Program Files\OpenZFS On Windows"
+#      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 
     - name: debug - get status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
 
 
@@ -363,81 +357,81 @@ jobs:
 
     - name: tests/functional/cli_root/zpool_create/zpool_create_001_pos
       timeout-minutes: 1
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test01 \\?\${{github.workspace}}\test01.dat'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test01 \\?\${{github.workspace}}\test01.dat'
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
-      timeout-minutes: 1
-    - run: Start-Sleep -Seconds 10
-      timeout-minutes: 1
-
-    - run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe" mount'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test01'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe" mount'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test02 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test01'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test02'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test02 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test03 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test02'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test03'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test03 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test04 mirror \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test03'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test04'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test04 mirror \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test05 mirror \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test04'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test05'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test05 mirror \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test06 raidz \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test05'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test06'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test06 raidz \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test07 raidz1 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test06'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
 
-    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test07'
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test07 raidz1 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+      timeout-minutes: 1
+    - run: Start-Sleep -Seconds 10
+      timeout-minutes: 1
+
+    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test07'
       timeout-minutes: 1
     - run: Start-Sleep -Seconds 10
       timeout-minutes: 1
@@ -446,7 +440,7 @@ jobs:
 
 
     - name: uninstall zfs
-      run: 'Start-Process -FilePath "C:\Program Files\OpenZFS On Windows\unins000.exe" -Wait -ArgumentList "/NORESTART /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Uninstall.log`""'
+      run: 'Start-Process -FilePath "${{ steps.registryzfs.outputs.zfspath }}\unins000.exe" -Wait -ArgumentList "/NORESTART /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Uninstall.log`""'
 
     - name: debug - print log
       run: cat "${{github.workspace}}\InnoSetup-Uninstall.log"
@@ -583,23 +577,24 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
 #    - name: debug - print log
 #      run: cat "${{github.workspace}}\InnoSetup-Install.log"
-#
+
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
 #    - name: debug - list
 #      run: ls "C:\Program Files"
 #
 #    - name: debug - list
-#      run: ls "C:\Program Files\OpenZFS On Windows"
+#      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 
     - name: debug - get status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
 
 
@@ -614,17 +609,17 @@ jobs:
           $f.Close()
 
     - name: create pool
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
 
     - name: get pool status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
     - name: get pool mount
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe" mount'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe" mount'
 
     - name: get pool mount
       id: drive  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):\"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):\"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
 
 
     - name: echo
@@ -866,7 +861,7 @@ jobs:
     #- name: run export zpool
     #  if: ${{ always() }}
     #  timeout-minutes: 1
-    #  run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" export tank'
+    #  run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" export tank'
 
 
 
@@ -984,23 +979,24 @@ jobs:
 #    - name: install zfs
 #      run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 #
-#    #- name: Wait for install to finish
-#    #  run: Start-Sleep -Seconds 30
-#    #  uses: iFaxity/wait-on-action@v1
-#    #  with:
-#    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-#
 ##    - name: debug - print log
 ##      run: cat "${{github.workspace}}\InnoSetup-Install.log"
+##
+##    - name: Get InstallLocation Registry Value
+##      id: registryzfs
+##      run: |
+##        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+##        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+##        Write-Host "Found installation location $value"
 ##
 ##    - name: debug - list
 ##      run: ls "C:\Program Files"
 ##
 ##    - name: debug - list
-##      run: ls "C:\Program Files\OpenZFS On Windows"
+##      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 #
 #    - name: debug - get status
-#      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+#      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 #
 #
 #
@@ -1023,49 +1019,49 @@ jobs:
 ##    - run: choco install gsudo
 #
 #    - name: tests/functional/cli_root/zpool_create/zpool_create_001_pos
-#      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test01 \\?\${{github.workspace}}\test01.dat'
+#      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test01 \\?\${{github.workspace}}\test01.dat'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test01'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test01'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test02 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test02 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test02'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test02'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test03 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test03 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test03'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test03'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test04 mirror \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test04 mirror \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test04'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test04'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test05 mirror \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test05 mirror \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test05'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test05'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test06 raidz \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test06 raidz \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test06'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test06'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create -f test07 raidz1 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create -f test07 raidz1 \\?\${{github.workspace}}\test01.dat \\?\${{github.workspace}}\test02.dat \\?\${{github.workspace}}\test03.dat'
 #    - run: Start-Sleep -Seconds 10
 #
-#    - run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" destroy -f test07'
+#    - run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" destroy -f test07'
 #    - run: Start-Sleep -Seconds 10
 #
 #
@@ -1238,23 +1234,23 @@ jobs:
 ##        $f.Close()
 ##
 ##    - name: create pool
-##      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create tank \\?\${{github.workspace}}\test.dat'
+##      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create tank \\?\${{github.workspace}}\test.dat'
 ##
 ##    - name: get pool status
-##      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+##      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 ##
 ##    - name: get pool mount
-##      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe" mount'
+##      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe" mount'
 ##
 ##    - name: get pool mount
 ##      id: drive  # Remember to give an ID if you need the output filename
-##      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:\\)"  | % {"::set-output name=drive::$($_.matches.groups[1].value)"}'
+##      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]:\\)"  | % {"::set-output name=drive::$($_.matches.groups[1].value)"}'
 ##
 ##    - name: echo
 ##      run: echo ${{ steps.drive.outputs.drive }}
 ##
 ##    - name: get
-##      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe" get all'
+##      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe" get all'
 ##
 ##    - name: get bcd
 ##      run: 'bcdedit'
@@ -1397,7 +1393,7 @@ jobs:
 ##    #- name: run export zpool
 ##    #  if: ${{ always() }}
 ##    #  timeout-minutes: 1
-##    #  run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" export tank'
+##    #  run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" export tank'
 ##
 ##
 ##
@@ -1556,23 +1552,24 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
 #    - name: debug - print log
 #      run: cat "${{github.workspace}}\InnoSetup-Install.log"
-#
+
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
 #    - name: debug - list
 #      run: ls "C:\Program Files"
 #
 #    - name: debug - list
-#      run: ls "C:\Program Files\OpenZFS On Windows"
+#      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 
     - name: debug - get status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
 
 
@@ -1587,21 +1584,21 @@ jobs:
           $f.Close()
 
     - name: create pool
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
 
     - name: get pool status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
     - name: get pool mount
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe" mount'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe" mount'
 
     - name: get pool mount
       id: drive  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):\"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):\"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
 
     - name: get pool mount
       id: drivenoslash  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
 
     - name: echo
       run: echo ${{ steps.drive.outputs.drive }}
@@ -1886,23 +1883,24 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
 #    - name: debug - print log
 #      run: cat "${{github.workspace}}\InnoSetup-Install.log"
-#
+
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
 #    - name: debug - list
 #      run: ls "C:\Program Files"
 #
 #    - name: debug - list
-#      run: ls "C:\Program Files\OpenZFS On Windows"
+#      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 
     - name: debug - get status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
 
 
@@ -1917,17 +1915,17 @@ jobs:
           $f.Close()
 
     - name: create pool
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
 
     - name: get pool status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
     - name: get pool mount
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe" mount'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe" mount'
 
     - name: get pool mount
       id: drive  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):\"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):\"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
 
     - name: echo
       run: echo ${{ steps.drive.outputs.drive }}
@@ -2142,23 +2140,24 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
 #    - name: debug - print log
 #      run: cat "${{github.workspace}}\InnoSetup-Install.log"
-#
+
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
 #    - name: debug - list
 #      run: ls "C:\Program Files"
 #
 #    - name: debug - list
-#      run: ls "C:\Program Files\OpenZFS On Windows"
+#      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 
     - name: debug - get status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
 
 
@@ -2291,23 +2290,24 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
 #    - name: debug - print log
 #      run: cat "${{github.workspace}}\InnoSetup-Install.log"
-#
+
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
 #    - name: debug - list
 #      run: ls "C:\Program Files"
 #
 #    - name: debug - list
-#      run: ls "C:\Program Files\OpenZFS On Windows"
+#      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 
     - name: debug - get status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
 
 
@@ -2452,23 +2452,24 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
 #    - name: debug - print log
 #      run: cat "${{github.workspace}}\InnoSetup-Install.log"
-#
+
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
 #    - name: debug - list
 #      run: ls "C:\Program Files"
 #
 #    - name: debug - list
-#      run: ls "C:\Program Files\OpenZFS On Windows"
+#      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 
     - name: debug - get status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
 
 
@@ -2483,21 +2484,21 @@ jobs:
           $f.Close()
 
     - name: create pool
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" create tank \\?\${{github.workspace}}\test01.dat'
 
     - name: get pool status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
     - name: get pool mount
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe" mount'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe" mount'
 
     - name: get pool mount
       id: drive  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):\"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):\"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
 
     - name: get pool mount
       id: drivenoslash  # Remember to give an ID if you need the output filename
-      run: '& "C:\Program Files\OpenZFS On Windows\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zfs.exe"  mount | Select-String -Pattern "^tank +([A-Za-z]):[/\\]"  | % {"drive=$($_.matches.groups[1].value):"} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append'
 
     - name: echo
       run: echo ${{ steps.drive.outputs.drive }}
@@ -2682,23 +2683,24 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
 #    - name: debug - print log
 #      run: cat "${{github.workspace}}\InnoSetup-Install.log"
-#
+
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
 #    - name: debug - list
 #      run: ls "C:\Program Files"
 #
 #    - name: debug - list
-#      run: ls "C:\Program Files\OpenZFS On Windows"
+#      run: ls "${{ steps.registryzfs.outputs.zfspath }}"
 
     - name: debug - get status
-      run: '& "C:\Program Files\OpenZFS On Windows\zpool.exe" status'
+      run: '& "${{ steps.registryzfs.outputs.zfspath }}\zpool.exe" status'
 
 
 
@@ -2788,5 +2790,12 @@ jobs:
     - name: install zfs
       run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.zfsinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
 
+    - name: Get InstallLocation Registry Value
+      id: registryzfs
+      run: |
+        $value = (Get-ItemProperty -Path "HKLM:\Software\OpenZFS\OpenZFS On Windows")."InstallLocation"
+        echo "zfspath=$value" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        Write-Host "Found installation location $value"
+
     - name: test
-      run: 'python.exe -u "${{github.workspace}}\contrib\windows\tests\regression.py" --path ${{github.workspace}}\'
+      run: 'python.exe -u "${{github.workspace}}\contrib\windows\tests\regression.py" --path "${{github.workspace}}" --zfspath "${{ steps.registryzfs.outputs.zfspath }}"'

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -79,36 +79,12 @@ jobs:
     - name: debug - get git rev
       run: git describe --always --long --dirty
 
-    - name: Download Inno Setup istaller
-      uses: suisei-cn/actions-download-file@v1.3.0
-      id: innoinstaller
-      with:
-        url: 'https://jrsoftware.org/download.php/is.exe'
-        target: ${{github.workspace}}/
-
-    - name: debug - echo filename
-      run: echo ${{ steps.innoinstaller.outputs.filename }}
-
-    - name: debug - list
-      run: ls ${{github.workspace}}\
-
-    - name: debug - list
-      run: ls ${{github.workspace}}\${{ steps.innoinstaller.outputs.filename }}
-
-    - name: install inno
-      run: 'Start-Process -FilePath "${{github.workspace}}\${{ steps.innoinstaller.outputs.filename }}" -Wait -ArgumentList "/NORESTART /ALLUSERS /VERYSILENT /LOG=`"${{github.workspace}}\InnoSetup-Install.log`""'
-
-    #- name: Wait for install to finish
-    #  run: Start-Sleep -Seconds 30
-    #  uses: iFaxity/wait-on-action@v1
-    #  with:
-    #    resource: 'C:\Program Files\OpenZFS On Windows\zpool.exe'
-
-    - name: debug - print log
-      run: cat "${{github.workspace}}\InnoSetup-Install.log"
+    # InnoSetup is part of the Github actions runner
+    # - name: Install InnoSetup
+    #   run: choco install -y InnoSetup
 
     - name: run ISCC.exe to construct OpenZFS installer
-      run: '&"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" .\ZFSInstall-debug.iss "/Ssigntoolc=C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe sign /v /fd sha256 /n `$qOpenZFS Test Signing Certificate`$q /t http://timestamp.digicert.com `$f" | Tee-Object -FilePath "${{github.workspace}}\iscc.log"'
+      run: '&"${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" .\ZFSInstall-debug.iss "/Ssigntoolc=${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe sign /v /fd sha256 /n `$qOpenZFS Test Signing Certificate`$q /t http://timestamp.digicert.com `$f" | Tee-Object -FilePath "${{github.workspace}}\iscc.log"'
       working-directory: ${{github.workspace}}\contrib\windows\Inno.Setup
 
     #- name: debug - get exe name

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -22,6 +22,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
+  IS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
 
 jobs:
   build_windows:
@@ -41,6 +42,7 @@ jobs:
 
     - name: debug - git status
       run: git status
+      if: ${{ env.IS_STEP_DEBUG == 'true' }}
 
     #https://stackoverflow.com/a/60883893
     #  "C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +90acd8f20e6d0c14b83241cc7dcd17df27d5a95b:refs/remotes/origin/andrew_workflows-7
@@ -159,6 +161,7 @@ jobs:
 
     - name: debug - print log
       run: cat "${{github.workspace}}\InnoSetup-Install.log"
+      if: ${{ env.IS_STEP_DEBUG == 'true' }}
 
     - name: Check InstallLocation Registry Value
       run: |


### PR DESCRIPTION
This improves the tests a bit:

- read ZFS install location from registry
- don't install InnoSetup, it is part of the GitHub action runner
- add env var IS_STEP_DEBUG to conditionally run debug prints