### PR TITLE
tests: Fix return type of zpool_create

### DIFF
--- a/contrib/windows/tests/utils.py
+++ b/contrib/windows/tests/utils.py
@@ -399,7 +399,7 @@ def zpool_create(
     devices: typing.Iterable[os.PathLike],
     zpool_options: typing.Dict[str, str] = {},
     zfs_options: typing.Dict[str, str] = {},
-) -> pathlib.Path:
+) -> ZpoolInfo:
     """Context manager that creates a zpool and destroys it when done
 
     Args:


### PR DESCRIPTION
The return value was annotated with `pathlib.Path` but `ZpoolInfo` is returned instead.