### PR TITLE
cmake: make GetGitRevisionDescription work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(OpenSSL REQUIRED)
 
 # Attempt to simulate scripts/make-gitrev.h and zfs_gitrev.h
 include(GetGitRevisionDescription)
-include(GetGitRevisionDescription)
+get_git_head_revision(GIT_REFSPEC GIT_HASH)
 git_describe_working_tree(GIT_GITREV)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/zfs_gitrev.h.win" "${CMAKE_CURRENT_SOURCE_DIR}/include/zfs_gitrev.h" @ONLY)
 #

--- a/contrib/windows/cmake/GetGitRevisionDescription.cmake
+++ b/contrib/windows/cmake/GetGitRevisionDescription.cmake
@@ -68,7 +68,7 @@ function(_git_find_closest_git_dir _start_dir _git_dir_var)
     while(NOT EXISTS "${git_dir}")
         # .git dir not found, search parent directories
         set(git_previous_parent "${cur_dir}")
-        get_filename_component(cur_dir ${cur_dir} DIRECTORY)
+        get_filename_component(cur_dir "${cur_dir}" DIRECTORY)
         if(cur_dir STREQUAL git_previous_parent)
             # We have reached the root directory, we are not in git
             set(${_git_dir_var}
@@ -94,7 +94,8 @@ function(get_git_head_revision _refspecvar _hashvar)
     if(NOT "${GIT_DIR}" STREQUAL "")
         file(RELATIVE_PATH _relative_to_source_dir "${CMAKE_SOURCE_DIR}"
              "${GIT_DIR}")
-        if("${_relative_to_source_dir}" MATCHES "[.][.]" AND NOT ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR)
+        if("${_relative_to_source_dir}" MATCHES "[.][.]"
+           AND NOT ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR)
             # We've gone above the CMake root dir.
             set(GIT_DIR "")
         endif()

--- a/contrib/windows/cmake/GetGitRevisionDescription.cmake.in
+++ b/contrib/windows/cmake/GetGitRevisionDescription.cmake.in
@@ -4,12 +4,12 @@
 # Requires CMake 2.6 or newer (uses the 'function' command)
 #
 # Original Author:
-# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# 2009-2023 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
 # http://academic.cleardefinition.com
 # Iowa State University HCI Graduate Program/VRAC
 #
 # Copyright 2009-2012, Iowa State University
-# Copyright 2011-2015, Contributors
+# Copyright 2011-2023, Contributors
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
@@ -21,23 +21,26 @@ file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
 
 string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
 if(HEAD_CONTENTS MATCHES "ref")
-	# named branch
-	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
-	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
-		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
-	else()
-		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
-		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
-		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
-			set(HEAD_HASH "${CMAKE_MATCH_1}")
-		endif()
-	endif()
+    # named branch
+    string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+    if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+        configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+    else()
+        if(EXISTS "@GIT_DIR@/packed-refs")
+            configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs"
+                           COPYONLY)
+            file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+            if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+                set(HEAD_HASH "${CMAKE_MATCH_1}")
+            endif()
+        endif()
+    endif()
 else()
-	# detached HEAD
-	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+    # detached HEAD
+    configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
 endif()
 
 if(NOT HEAD_HASH)
-	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
-	string(STRIP "${HEAD_HASH}" HEAD_HASH)
+    file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+    string(STRIP "${HEAD_HASH}" HEAD_HASH)
 endif()


### PR DESCRIPTION
The current build does only update `zfs_gitrev.h` on the first configuration run but then not change it when the commit changes.

To fix this we need to call `get_git_head_revision`.

This also updates `GetGitRevisionDescription` to the latest version from https://github.com/rpavlik/cmake-modules/tree/d66fc5dec3eaea3a4f9778ceeeb65cbec490b5b9