### PR TITLE
spl-time: Use KeQueryPerformanceCounter instead of KeQueryTickCount

### DIFF
--- a/module/os/windows/spl/spl-time.c
+++ b/module/os/windows/spl/spl-time.c
@@ -55,9 +55,12 @@ gethrtime(void)
 	LARGE_INTEGER now;
 	if (start.QuadPart == 0) {
 		start = KeQueryPerformanceCounter(&freq);
+		ASSERT(freq.QuadPart < NANOSEC);
+		ASSERT(freq.QuadPart > 0);
+		freq.QuadPart = NANOSEC / freq.QuadPart;
 	}
 	now = KeQueryPerformanceCounter(NULL);
-	return (now.QuadPart - start.QuadPart) * (NANOSEC / freq.QuadPart);
+	return ((now.QuadPart - start.QuadPart) * freq.QuadPart);
 }
 
 /*


### PR DESCRIPTION
`KeQueryTickCount` seems to only have a 15.625ms resolution unless the interrupt timer frequency is increased, which should be avoided due to power usage.

Instead, this switches the `zfs_lbolt`, `gethrtime` and `random_get_bytes` to use `KeQueryPerformanceCounter`.

On my system this gives a 100ns resolution.
