### PR TITLE
zfs_vnops_windows: fix volume disk extent length

### DIFF
--- a/.github/workflows/codeql-windows.yml
+++ b/.github/workflows/codeql-windows.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: windows-build-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -150,6 +150,6 @@ jobs:
           cmake --build "${{ github.workspace }}/out/build/x64-Debug" --parallel
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
 
 

--- a/module/os/windows/zfs/zfs_vnops_windows.c
+++ b/module/os/windows/zfs/zfs_vnops_windows.c
@@ -7638,7 +7638,7 @@ ioctl_volume_get_volume_disk_extents(PDEVICE_OBJECT DeviceObject,
 			dmu_objset_space(zfsvfs->z_os,
 			    &refdbytes, &availbytes, &usedobjs, &availobjs);
 			vde->Extents[0].ExtentLength.QuadPart =
-			    refdbytes * availbytes;
+			    refdbytes + availbytes;
 			zfs_exit(zfsvfs, FTAG);
 		}
 	}

--- a/module/os/windows/zfs/zfs_vnops_windows_lib.c
+++ b/module/os/windows/zfs/zfs_vnops_windows_lib.c
@@ -6346,6 +6346,7 @@ ioctl_disk_get_drive_geometry(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	}
 
 	DISK_GEOMETRY *diskGeometry = Irp->AssociatedIrp.SystemBuffer;
+	RtlZeroMemory(diskGeometry, sizeof (*diskGeometry));
 	unsigned long TracksPerCylinder = 255;
 	unsigned long SectorsPerTrack = 63;
 	unsigned long BytesPerSector = 512;
@@ -6420,6 +6421,8 @@ ioctl_disk_get_drive_geometry_ex(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
 	// DISK_GEOMETRY_EX_INTERNAL *geom = Irp->AssociatedIrp.SystemBuffer;
 	DISK_GEOMETRY_EX *geom = Irp->AssociatedIrp.SystemBuffer;
+	RtlZeroMemory(geom,
+	    IrpSp->Parameters.DeviceIoControl.OutputBufferLength);
 
 	zfsvfs_t *zfsvfs = vfs_fsprivate(zmo);
 	if (zfsvfs == NULL) {
@@ -6492,6 +6495,7 @@ ioctl_disk_get_partition_info(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	    &refdbytes, &availbytes, &usedobjs, &availobjs);
 
 	PARTITION_INFORMATION *part = Irp->AssociatedIrp.SystemBuffer;
+	RtlZeroMemory(part, sizeof (*part));
 
 	part->PartitionLength.QuadPart = availbytes + refdbytes;
 	part->StartingOffset.QuadPart = 0;
@@ -6541,6 +6545,7 @@ ioctl_disk_get_partition_info_ex(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	    &refdbytes, &availbytes, &usedobjs, &availobjs);
 
 	PARTITION_INFORMATION_EX *part = Irp->AssociatedIrp.SystemBuffer;
+	RtlZeroMemory(part, sizeof (*part));
 
 	part->PartitionStyle = PARTITION_STYLE_MBR;
 	part->RewritePartition = FALSE;
@@ -6591,6 +6596,7 @@ ioctl_disk_get_length_info(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	    &refdbytes, &availbytes, &usedobjs, &availobjs);
 
 	GET_LENGTH_INFORMATION *gli = Irp->AssociatedIrp.SystemBuffer;
+	RtlZeroMemory(gli, sizeof (*gli));
 	gli->Length.QuadPart = availbytes + refdbytes;
 
 	zfs_exit(zfsvfs, FTAG);


### PR DESCRIPTION
Targeted at `zfs-Windows-2.4.1-release` because it is the current `zfswin-2.4.1rc11` release branch.  Please let me know if `development` is preferred.

### Motivation and Context

<img width="229" height="99" alt="2c729121825bbedc769dead2a2a66147" src="https://github.com/user-attachments/assets/e286b83c-24f7-4ddb-9cfa-f21f2faf3477" />

(Task Manager showing the incorrect volume size before the fix)

The volume disk extent handler should report the same byte count used by the other disk and partition size handlers.

### Description

Use `refdbytes + availbytes` for `IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS`.

Also zero-initialize several disk geometry and partition output buffers before filling the fields OpenZFS returns.

### How Has This Been Tested?

By Agent:
- Tested on Windows Server 2022 with a test-signed x64 driver based on `zfswin-2.4.1rc11`.
- Created a file-backed pool and encrypted dataset.
- Wrote data, ran `zpool sync`, and verified SHA256 readback.
- `zpool status` remained `ONLINE` with no known data errors.

By Human:
- A test-signed rc10 build containing this change has been used on my daily-use Windows PC since 2026-05-13 with no observed issues. The corrected volume size path was also confirmed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
